### PR TITLE
Fix Ubisoft Connect Not Working

### DIFF
--- a/TcNo-Acc-Switcher-Server/Platforms.json
+++ b/TcNo-Acc-Switcher-Server/Platforms.json
@@ -272,6 +272,7 @@
       "PathListToClear": [ "SAME_AS_LOGIN_FILES" ],
       "LoginFiles": {
         "%Platform_Folder%\\logs\\launcher_log.txt": "logs\\launcher_log.txt",
+        "%LocalAppData%\\Ubisoft Game Launcher\\ConnectSecureStorage.dat": "ConnectSecureStorage.dat",
         "%LocalAppData%\\Ubisoft Game Launcher\\settings.yaml": "settings.yaml",
         "%LocalAppData%\\Ubisoft Game Launcher\\user.dat": "user.dat"
       },


### PR DESCRIPTION
* Fix TcNo switcher not being able to save / login multiple accounts for ubisoft connect.