### PR TITLE
Fix Profile Photos Not Being Assigned For Ubisoft Accounts

### DIFF
--- a/TcNo-Acc-Switcher-Server/Pages/Basic/BasicSwitcherFuncs.cs
+++ b/TcNo-Acc-Switcher-Server/Pages/Basic/BasicSwitcherFuncs.cs
@@ -647,7 +647,7 @@ namespace TcNo_Acc_Switcher_Server.Pages.Basic
                         {
                             // The regex result should be considered a filename.
                             // Sub in %FileName% from res, and %UniqueId% from uniqueId
-                            sourcePath = ExpandEnvironmentVariables(CurrentPlatform.ProfilePicPath.Replace("%FileName%", res).Replace("%UniqueId", uniqueId));
+                            sourcePath = ExpandEnvironmentVariables(CurrentPlatform.ProfilePicPath.Replace("%FileName%", res).Replace("%UniqueId%", uniqueId));
                         }
 
                         if (res != "" && File.Exists(sourcePath))
@@ -656,7 +656,7 @@ namespace TcNo_Acc_Switcher_Server.Pages.Basic
                     }
                     else if (CurrentPlatform.ProfilePicPath != "")
                     {
-                        var sourcePath = ExpandEnvironmentVariables(Globals.GetCleanFilePath(CurrentPlatform.ProfilePicPath.Replace("%UniqueId", uniqueId))) ?? "";
+                        var sourcePath = ExpandEnvironmentVariables(CurrentPlatform.ProfilePicPath.Replace("%UniqueId%", uniqueId)) ?? "";
                         if (sourcePath != "" && File.Exists(sourcePath))
                             if (!Globals.CopyFile(sourcePath, profileImg))
                                 Globals.WriteToLog("Tried to save profile picture from path (ProfilePicPath method)");

--- a/TcNo-Acc-Switcher-Server/Pages/General/GeneralFuncs.cs
+++ b/TcNo-Acc-Switcher-Server/Pages/General/GeneralFuncs.cs
@@ -173,10 +173,14 @@ namespace TcNo_Acc_Switcher_Server.Pages.General
             Globals.DebugWriteLine(@"[Func:General\GeneralSwitcherFuncs.ForgetAccount_Generic] Forgetting account: hidden, Platform: " + platform);
 
             // Remove ID from list of ids
-            var idsFile = $"LoginCache\\{platform}\\ids.json";
+            var idsFile = Path.Join(Globals.UserDataFolder, $"LoginCache\\{platform}\\ids.json");
+            var orderFile = Path.Join(Globals.UserDataFolder, $"LoginCache\\{platform}\\order.json");
+            var ogAccName = accName;
+
             if (File.Exists(idsFile))
             {
                 var allIds = ReadDict(idsFile);
+                
                 if (accNameIsId)
                 {
                     var accId = accName;
@@ -185,14 +189,26 @@ namespace TcNo_Acc_Switcher_Server.Pages.General
                 }
                 else
                     _ = allIds.Remove(allIds.Single(x => x.Value == accName).Key);
+
                 File.WriteAllText(idsFile, JsonConvert.SerializeObject(allIds));
             }
 
+            if (File.Exists(orderFile))
+            {
+
+                Task.Run(async () =>
+                {
+                    var savedOrder = JsonConvert.DeserializeObject<List<string>>(await File.ReadAllTextAsync(orderFile).ConfigureAwait(false));
+                    savedOrder.Remove(ogAccName);
+                    File.WriteAllText(orderFile, JsonConvert.SerializeObject(savedOrder));
+                }).Wait();
+            }
+
             // Remove cached files
-            Globals.RecursiveDelete($"LoginCache\\{platform}\\{accName}", false);
+            Globals.RecursiveDelete(Path.Join(Globals.UserDataFolder, $"LoginCache\\{platform}\\{accName}"), false);
 
             // Remove image
-            Globals.DeleteFile(Path.Join(WwwRoot(), $"\\img\\profiles\\{platform}\\{Globals.GetCleanFilePath(accName)}.jpg"));
+            Globals.DeleteFile(Path.Join(WwwRoot(), $"\\img\\profiles\\{platform}\\{Globals.GetCleanFilePath(ogAccName)}.jpg"));
 
             // Remove from Tray
             Globals.RemoveTrayUser(platform, accName); // Add to Tray list
@@ -242,7 +258,7 @@ namespace TcNo_Acc_Switcher_Server.Pages.General
 
         public static string WwwRoot()
         {
-            return Path.Join(Globals.UserDataFolder, "\\wwwroot");
+            return Path.Join(Globals.UserDataFolder, "wwwroot");
         }
 
         // Overload for below


### PR DESCRIPTION
* Fix the incomplete environment variable that should be replaced.
* Fix the incomplete path used for checking ids and the incorrect function call to clean the path
* Fix the issue with clearing old account images (was using account name rather than id to clear the image)
* Some additional path cleanup and fix the stored order of the users not having the removed user id not removed from the order.

P.S: To fix the profile photo not showing users will need to forget their account and save the account again, to show their profile photo. This behavior could be changed but feedback is necessary.