### PR TITLE
Fix tray menu labels and Steam profile images

### DIFF
--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -320,25 +320,37 @@ func menuBitmapForAccount(platformKey, arg string) []byte {
 	if uid == "" {
 		return nil
 	}
-	p, ok := profileimage.CachedFilePath(platformKey, uid)
-	if !ok {
-		return nil
-	}
-	st, err := os.Stat(p)
-	if err != nil || st.Size() > 512*1024 {
-		return nil
-	}
-	b, err := os.ReadFile(p)
-	if err != nil || len(b) == 0 {
-		return nil
-	}
-	out := cachedImageBytesAsMenuPNG(b)
-	if len(out) > 0 {
+	for _, imageID := range trayImageCandidateIDs(platformKey, uid) {
+		p, ok := profileimage.CachedFilePath(platformKey, imageID)
+		if !ok {
+			continue
+		}
+		st, err := os.Stat(p)
+		if err != nil || st.Size() > 512*1024 {
+			continue
+		}
+		b, err := os.ReadFile(p)
+		if err != nil || len(b) == 0 {
+			continue
+		}
+		out := cachedImageBytesAsMenuPNG(b)
+		if len(out) == 0 {
+			continue
+		}
 		menuBitmapCacheMu.Lock()
 		menuBitmapCache[key] = append([]byte(nil), out...)
 		menuBitmapCacheMu.Unlock()
+		return out
 	}
-	return out
+	return nil
+}
+
+func trayImageCandidateIDs(platformKey, uid string) []string {
+	ids := []string{uid}
+	if strings.EqualFold(strings.TrimSpace(platformKey), "steam") {
+		ids = append(ids, uid+"_static")
+	}
+	return ids
 }
 
 func cachedImageBytesAsMenuPNG(b []byte) []byte {

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -157,10 +157,10 @@ func (m *Manager) rebuildMenuLocked() {
 	tr := m.trayTranslator()
 
 	if security.AppLocked() {
-		menu.Add(tr("Tray_Unlock", nil)).OnClick(func(_ *application.Context) {
+		menu.Add(trayText(tr, "Tray_Unlock", nil, "Unlock")).OnClick(func(_ *application.Context) {
 			m.showHome()
 		})
-		menu.Add(tr("Tray_Exit", nil)).OnClick(func(_ *application.Context) {
+		menu.Add(trayText(tr, "Tray_Exit", nil, "Exit")).OnClick(func(_ *application.Context) {
 			m.SetQuitting(true)
 			m.app.Quit()
 		})
@@ -199,7 +199,8 @@ func (m *Manager) rebuildMenuLocked() {
 		for _, u := range list {
 			u := u
 			plat := plat
-			item := sub.Add(tr("Tray_Switch", map[string]string{"account": u.Name}))
+			vars := map[string]string{"account": u.Name}
+			item := sub.Add(trayText(tr, "Tray_Switch", vars, "Switch to: {account}"))
 			if b := menuBitmapForAccount(plat, u.Arg); len(b) > 0 {
 				item.SetBitmap(b)
 			}
@@ -217,12 +218,25 @@ func (m *Manager) rebuildMenuLocked() {
 	}
 
 	menu.AddSeparator()
-	menu.Add(tr("Tray_Exit", nil)).OnClick(func(_ *application.Context) {
+	menu.Add(trayText(tr, "Tray_Exit", nil, "Exit")).OnClick(func(_ *application.Context) {
 		m.SetQuitting(true)
 		m.app.Quit()
 	})
 
 	m.systray.SetMenu(menu)
+}
+
+// trayText keeps native tray menus readable when localization resources are
+// unavailable, while preserving translated labels whenever they resolve.
+func trayText(tr func(string, map[string]string) string, key string, vars map[string]string, fallback string) string {
+	translated := strings.TrimSpace(tr(key, vars))
+	if translated != "" && translated != key {
+		return translated
+	}
+	for name, value := range vars {
+		fallback = strings.ReplaceAll(fallback, "{"+name+"}", value)
+	}
+	return fallback
 }
 
 func (m *Manager) trayTranslator() func(string, map[string]string) string {

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -321,6 +321,9 @@ func menuBitmapForAccount(platformKey, arg string) []byte {
 		return nil
 	}
 	for _, imageID := range trayImageCandidateIDs(platformKey, uid) {
+		if imageID != uid && profileimage.HasManualProfileMarker(platformKey, uid) {
+			continue
+		}
 		p, ok := profileimage.CachedFilePath(platformKey, imageID)
 		if !ok {
 			continue

--- a/internal/tray/tray_bitmap_test.go
+++ b/internal/tray/tray_bitmap_test.go
@@ -1,0 +1,68 @@
+package tray
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"TcNo-Acc-Switcher/internal/paths"
+	"TcNo-Acc-Switcher/internal/profileimage"
+)
+
+func TestMenuBitmapRespectsManualAvatar(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("tray bitmaps are Windows-only")
+	}
+	paths.InitDataRoot(t.TempDir())
+	dir, err := profileimage.ProfileDir("Steam")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var static bytes.Buffer
+	if err := png.Encode(&static, image.NewRGBA(image.Rect(0, 0, 2, 2))); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name       string
+		id         string
+		manual     bool
+		primaryPNG bool
+		wantBitmap bool
+	}{
+		{"Steam video uses static fallback", "76561190000000001", false, false, true},
+		{"manual video ignores old static avatar", "76561190000000002", true, false, false},
+		{"manual image remains visible", "76561190000000003", true, true, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			write := func(name string, data []byte) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write(tt.id+"_static.png", static.Bytes())
+			if tt.primaryPNG {
+				write(tt.id+".png", static.Bytes())
+			} else {
+				// The tray image decoder cannot decode video files.
+				write(tt.id+".webm", []byte{0x1a, 0x45, 0xdf, 0xa3})
+			}
+			if tt.manual {
+				if err := profileimage.WriteManualProfileMarker("Steam", tt.id); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := menuBitmapForAccount("Steam", "+s:"+tt.id)
+			if (len(got) > 0) != tt.wantBitmap {
+				t.Fatalf("bitmap present = %v, want %v", len(got) > 0, tt.wantBitmap)
+			}
+		})
+	}
+}

--- a/internal/tray/tray_test.go
+++ b/internal/tray/tray_test.go
@@ -1,0 +1,36 @@
+package tray
+
+import "testing"
+
+func TestTrayTextFallsBackWhenTranslationMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		tr   func(string, map[string]string) string
+	}{
+		{
+			name: "translation key returned",
+			tr:   func(key string, _ map[string]string) string { return key },
+		},
+		{
+			name: "empty translation returned",
+			tr:   func(string, map[string]string) string { return "" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trayText(tt.tr, "Tray_Switch", map[string]string{"account": "Marc"}, "Switch to: {account}")
+			if got != "Switch to: Marc" {
+				t.Fatalf("tray text = %q, want %q", got, "Switch to: Marc")
+			}
+		})
+	}
+}
+
+func TestTrayTextUsesTranslation(t *testing.T) {
+	tr := func(_ string, _ map[string]string) string { return "Cambiar a: Marc" }
+	got := trayText(tr, "Tray_Switch", map[string]string{"account": "Marc"}, "Switch to: {account}")
+	if got != "Cambiar a: Marc" {
+		t.Fatalf("tray text = %q, want %q", got, "Cambiar a: Marc")
+	}
+}

--- a/internal/tray/tray_test.go
+++ b/internal/tray/tray_test.go
@@ -1,6 +1,9 @@
 package tray
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestTrayTextFallsBackWhenTranslationMissing(t *testing.T) {
 	tests := []struct {
@@ -32,5 +35,14 @@ func TestTrayTextUsesTranslation(t *testing.T) {
 	got := trayText(tr, "Tray_Switch", map[string]string{"account": "Marc"}, "Switch to: {account}")
 	if got != "Cambiar a: Marc" {
 		t.Fatalf("tray text = %q, want %q", got, "Cambiar a: Marc")
+	}
+}
+
+func TestTrayImageCandidateIDs(t *testing.T) {
+	if got, want := trayImageCandidateIDs("Steam", "7656119"), []string{"7656119", "7656119_static"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Steam candidates = %#v, want %#v", got, want)
+	}
+	if got, want := trayImageCandidateIDs("Epic", "account"), []string{"account"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Epic candidates = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Native tray menu labels can render as raw localization keys such as `Tray_Switch` and `Tray_Exit` in packaged/single-file builds when the frontend locale JSON files are not available beside the executable.

This adds a small tray-only fallback helper that:
- keeps the normal translated label when localization resolves successfully;
- falls back to readable English only when translation is empty or returns the key unchanged;
- substitutes tray variables such as the account name in the fallback text.

Steam tray entries now also fall back to the cached `_static` avatar variant when the primary profile image is unavailable, restoring profile pictures in the native tray menu.

The fallback is applied to `Tray_Switch`, `Tray_Unlock`, and `Tray_Exit`.

## Tests

Adds regression coverage for:
- untranslated-key fallback;
- empty-translation fallback;
- preserving a successful translated label.